### PR TITLE
#9 Fix tests

### DIFF
--- a/src/main/java/io/github/ilyalisov/storage/service/FirebaseStorageServiceImpl.java
+++ b/src/main/java/io/github/ilyalisov/storage/service/FirebaseStorageServiceImpl.java
@@ -115,7 +115,7 @@ public class FirebaseStorageServiceImpl implements StorageService {
         return blobs.stream()
                 .map(
                         (result) -> find(result.getName())
-                                .get()
+                                .orElseThrow()
                 )
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on refactoring a method in `FirebaseStorageServiceImpl.java` to use `orElseThrow()` instead of `get()`.

### Detailed summary
- Refactored the method in `FirebaseStorageServiceImpl.java` to use `orElseThrow()` instead of `get()`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->